### PR TITLE
Optimizing fetches from the DB

### DIFF
--- a/Sources/VaporSimplePagination.swift
+++ b/Sources/VaporSimplePagination.swift
@@ -3,7 +3,7 @@ import Fluent
 
 public extension Model {
     static func paginate(limit inLimit: Int = 10, page inPage: Int = 1, description inDescription: String = "data", makeJSON inMakeJSON: Bool = false) -> [JSON]? {
-        guard let total = try? self.all().count else { return nil }
+        guard let total = try? self.query().count() else { return nil }
         let offset = inLimit * (inPage - 1)
         guard let query = try? self.query().makeQuery() else { return nil }
         query.limit = Limit(count: inLimit, offset: offset)


### PR DESCRIPTION
When you use all() instead of query() you are making a full fetch of the objects which can consume memory and CPU to process. But by using query() you are just preparing a query and then by using the count() method it will run the query with count, fetching only the amount of objects with less data travel and more performance for big amount of objects.